### PR TITLE
Added "Set/Reveal Secret" command

### DIFF
--- a/new_magic/definition.xml
+++ b/new_magic/definition.xml
@@ -216,6 +216,7 @@
     <groupaction menu="Re-align Cards" execute="align" />
 	<groupaction menu="Change Automation Settings" execute="autoscriptMenu" />
     <groupaction menu="View Update Log" execute="changeLog" />
+    <groupaction menu="Set/Reveal Secret" execute="secret" />
     <cardaction menu="Tap/Untap or Resolve" default="True" batchExecute="batchResolve" />
     <cardaction menu="Exert (Don't Untap Next Untap Step)" shortcut="ctrl+V" execute="exert" />
     <cardaction menu="Keep Tapped During All Untap Steps" shortcut="ctrl+Shift+V" execute="doesNotUntap" />

--- a/new_magic/scripts/actions.py
+++ b/new_magic/scripts/actions.py
@@ -271,6 +271,41 @@ def changeLog(group, x = 0, y = 0):
         elif num == -3 and count > 1: ## If the player chooses 'newer'
             count -= 1
 
+def secret(group, x = 0, y = 0):
+    mute()
+    # this could be split into multiple askStrings
+    input = askString("Set/Reveal a secret.\n\nFirst input either Set, Reveal or RevealAll.\nThen the name of the secret.\nAnd lastly it's value, or nothing to clear (if setting).\nCase insensitive, separated by spaces.\nAn example would be \"Set Carrots 9\" (without quotes)", "")
+    if input != None:
+        input.lower()
+        ss = input.split(' ')
+        # each of these could be it's own function
+        if len(ss) == 3 and ss[0] == "set":
+            if len(ss) == 3 and ss[2] != None and len(ss[2]) > 0:
+                me.setGlobalVariable("secret_{}".format(ss[1]), ss[2])
+                notify("{} set secret \"{}\"".format(me, ss[1]))
+            else:
+                me.setGlobalVariable("secret_{}".format(ss[1]), "")
+                notify("{} cleared their \"{}\" secret".format(me, ss[1]))
+
+        elif len(ss) == 2 and ss[0] == "reveal":
+            mySecret = me.getGlobalVariable("secret_{}".format(ss[1]))
+            if mySecret != None and len(mySecret) > 0:
+                notify("{} revealed secret \"{}\" as {}".format(me, ss[1], mySecret))
+            else:
+                whisper("You haven't set that secret yet.")
+
+        elif len(ss) == 2 and ss[0] == "revealall":
+            notify("Revealing all \"{}\" secrets...".format(ss[1]))
+            for player in getPlayers():
+                theirSecret = player.getGlobalVariable("secret_{}".format(ss[1]))
+                if theirSecret != None and len(theirSecret) > 0:
+                    notify("{}'s secret is {}".format(player.name, theirSecret))
+                else:
+                    notify("{} has no secret".format(player.name))
+
+        else:
+            whisper("Your syntax for the command \"secret\" was incorrect.")
+
 #--------------------------------
 # Autoscript-Linked Card functions
 #--------------------------------

--- a/new_magic/scripts/actions.py
+++ b/new_magic/scripts/actions.py
@@ -276,7 +276,7 @@ def secret(group, x = 0, y = 0):
     # this could be split into multiple askStrings
     input = askString("Set/Reveal a secret.\n\nFirst input either Set, Reveal or RevealAll.\nThen the name of the secret.\nAnd lastly it's value, or nothing to clear (if setting).\nCase insensitive, separated by spaces.\nAn example would be \"Set Carrots 9\" (without quotes)", "")
     if input != None:
-        input.lower()
+        input = input.lower()
         ss = input.split(' ')
         # each of these could be it's own function
         if len(ss) == 3 and ss[0] == "set":
@@ -304,7 +304,7 @@ def secret(group, x = 0, y = 0):
                     notify("{} has no secret".format(player.name))
 
         else:
-            whisper("Your syntax for the command \"secret\" was incorrect.")
+            whisper("Incorrect syntax for \"Set/Reveal Secret\".")
 
 #--------------------------------
 # Autoscript-Linked Card functions


### PR DESCRIPTION
Added a "Set/Reveal Secret" command to allow players to store, reveal own, and reveal all players' hidden information, such as secret numbers or secretly chosen players for specific card effects (such as Stalking Leonin, or Wheel of Misfortune) that previously were difficult or impossible to resolve without giving players the ability to cheat.