### PR TITLE
New action: Take from library top X, shuffle rest

### DIFF
--- a/new_magic/definition.xml
+++ b/new_magic/definition.xml
@@ -291,6 +291,7 @@
     </group>
     <group name="Library" shortcut="ctrl+I" visibility="none" icon="groups/library.png">
       <groupaction menu="Scry" shortcut="ctrl+shift+C" execute="scry" />
+      <groupaction menu="Take card(s) from top X, shuffle rest to bottom" execute="takeFromLibraryTopXShuffleRest" />
       <groupaction menu="Draw" shortcut="ctrl+D" default="True" execute="draw" />
       <groupaction menu="Draw X Cards" shortcut="ctrl+shift+D" execute="drawMany" />
       <groupaction menu="Mill X Cards" execute="mill" />

--- a/new_magic/scripts/actions.py
+++ b/new_magic/scripts/actions.py
@@ -414,6 +414,44 @@ def scry(group = me.Library, x = 0, y = 0, count = None):
     notify("{} scryed for {}, {} on top, {} on bottom.".format(me, count, len(dlg.list), len(dlg.bottomList)))
     group.visibility = "none"
 
+def takeFromLibraryTopXShuffleRest(_group = None, _x = None, _y = None, count = None):
+    """Allows a player to take card(s) from the top X cards of their library and shuffles the rest to the bottom.
+    The taken cards are put into player's hand and can be automatically revealed to opponents, if desired."""
+    mute()
+    if count == None:
+        count = askInteger("Take from how many top cards?", 5)
+    if count == None or count == 0:
+        return
+    dlg = cardDlg(list=[], bottomList=me.Library.top(count))
+    dlg.title = "Take card(s) from top {}, shuffle rest to bottom".format(count)
+    dlg.label = "To hand"
+    dlg.bottomLabel = "To the bottom of library in a random order"
+    dlg.text = "Select card(s) to put into your hand. The rest will be put on the bottom of your library in a random order." \
+               "You'll be asked if you want to reveal selected cards."
+    if dlg.show() is None:
+        notify("{} has cancelled taking cards from top {} of their library.".format(me, count))
+        return
+
+    if len(dlg.list) > 0:
+        shouldReveal = confirm("Do you want to reveal taken cards to all your opponents?")
+    else:
+        shouldReveal = False
+    if shouldReveal is None:
+        shouldReveal = False ## If user closes the window, we treat it as if they said "don't reveal".
+
+    if shouldReveal:
+        for c in dlg.list:
+            me.Library[c.index].isFaceUp = True ## c.isFaceUp doesn't work for cards in piles.
+        cardInfo = ', '.join("{}".format(c) for c in dlg.list)
+    else:
+        cardInfo = "{} card(s)".format(len(dlg.list))
+    notify("{} puts {} from top {} of their library to hand and the rest to the bottom of library in a random order.".format(me, cardInfo, count))
+    ## We notify after turning cards face up but before moving them because cards are turned face down again when moved.
+
+    for c in dlg.list:
+        c.moveTo(me.Hand)
+    libraryBottomAllShuffle(cards=dlg.bottomList, verbose=False)
+
 def play(card, x = 0, y = 0):
     mute()
     text = ''
@@ -980,7 +1018,7 @@ def tolibraryposition(card, x = 0, y = 0):
         notify("{} moves {} from {} to Library ({} from top).".format(me, card, fromText, pos))
         card.moveTo(card.owner.Library, pos)
 
-def libraryBottomAllShuffle(cards, x = 0, y = 0):
+def libraryBottomAllShuffle(cards, x = 0, y = 0, verbose = True):
     mute()
     count = len(cards)
     rng = Random()
@@ -990,7 +1028,8 @@ def libraryBottomAllShuffle(cards, x = 0, y = 0):
         cards[i], cards[j] = cards[j], cards[i]
     for card in cards:
         card.moveToBottom(card.owner.piles['Library'])
-    notify("{} shuffles {} selected cards to the bottom of their Library.".format(me, count))
+    if verbose:
+        notify("{} shuffles {} selected cards to the bottom of their Library.".format(me, count))
 
 def tohand(card, x = 0, y = 0):
     mute()


### PR DESCRIPTION
Fixes #125.

This adds a new action, which allows the user to have a look at top X cards from their library, take any number of them to hand using a Scry-like window (with the option of revealing these cards to all opponents), and then moves the rest to the bottom of library in a random order.

Effects of this kind are recently quite popular and until now resolving them was very inconvenient on OCTGN, as explained by #125.